### PR TITLE
docs: set default authentication type to QR in Basic Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ import { Client } from "zaileys";
 
 // default configuration
 const wa = new Client({
+  authType: "qr",
   prefix: "/",
   ignoreMe: true,
   showLogs: true,


### PR DESCRIPTION
Resolve #3 